### PR TITLE
Build task

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: NODE_ENV=production node app.js
+web: NODE_ENV=production npm start

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,12 +27,19 @@ gulp.task('develop', function () {
   })
 });
 
-gulp.task('clean', function(done) {
-  del(['./css/*.css', './html/*.html'], done);
-});
-
 gulp.task('watch', function() {
   gulp.watch('./sass/**/*.sass', ['sass']);
 });
 
-gulp.task('default', ['sass', 'watch', 'develop']);
+gulp.task('clean', function(done) {
+  del(['./css/*.css', './html/*.html'], done);
+});
+
+
+gulp.task('default',
+  ['sass', 'watch', 'develop']
+);
+
+gulp.task('build',
+  ['clean', 'sass']
+);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Server for remood.js",
   "main": "app.js",
   "scripts": {
+    "postinstall": "gulp build",
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -14,21 +16,18 @@
   "license": "ISC",
   "dependencies": {
     "blade": "^3.2.7",
-    "express": "^4.12.3",
-    "lodash": "^3.6.0",
-    "pluralize": "^1.1.2",
-    "randomstring": "^1.0.3",
-    "mobile-detect": "^0.4.3",
-    "socket.io": "^1.3.5"
-  },
-  "devDependencies": {
     "del": "^1.1.1",
+    "express": "^4.12.3",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.1.0",
     "gulp-flatten": "^0.0.4",
     "gulp-sass": "^1.3.3",
-    "gulp-slim": "0.0.13",
     "gulp-util": "^3.0.4",
-    "nodemon": "^1.3.7"
+    "lodash": "^3.6.0",
+    "mobile-detect": "^0.4.3",
+    "nodemon": "^1.3.7",
+    "pluralize": "^1.1.2",
+    "randomstring": "^1.0.3",
+    "socket.io": "^1.3.5"
   }
 }


### PR DESCRIPTION
For having `gulp` accessible by CloudControl, we need to list it - like all `gulp-*` plugins - in our `dependencies` object, instead of `devDependencies`.
