### PR TITLE
Implement bower

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,8 @@ var gulp = require('gulp'),
     del = require('del'),
     merge = require('merge-stream'),
     nodemon = require('nodemon')
-    sourcemaps = require('gulp-sourcemaps');
+    sourcemaps = require('gulp-sourcemaps'),
+    bower = require('gulp-bower');
 
 gulp.task('sass', function () {
   return cssBundler('./css');
@@ -20,6 +21,15 @@ gulp.task('clean', function(done) {
 });
 gulp.task('build:clean', function(done) {
   del(['./dist/*', '!./dist/.keep'], done);
+});
+
+gulp.task('bower', function() {
+  return bower()
+    .pipe(gulp.dest('./libraries/'));
+});
+gulp.task('build:bower', function() {
+  return bower()
+    .pipe(gulp.dest('./dist/libraries/'));
 });
 
 gulp.task('build:js', function() {
@@ -54,10 +64,10 @@ gulp.task('watch', function() {
 });
 
 gulp.task('default',
-  ['sass', 'watch', 'develop']
+  ['sass', 'bower', 'watch', 'develop']
 );
 gulp.task('build',
-  ['build:clean', 'build:sass', 'build:js', 'build:templates']
+  ['build:clean', 'build:sass', 'build:js', 'build:templates', 'build:bower']
 );
 
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express": "^4.12.3",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.1.0",
+    "gulp-bower": "0.0.10",
     "gulp-flatten": "^0.0.4",
     "gulp-sass": "^1.3.3",
     "gulp-sourcemaps": "^1.5.2",


### PR DESCRIPTION
We currently use cdn's to get our js libraries in the browser. This is bad, for so many reasons.

Lets remove them with a clean bower implementation, for speed, stability and reliability.

We then can even minify the libs only on production keep the code easy to read on dev environments.
